### PR TITLE
Add macOS support

### DIFF
--- a/Adapty.podspec
+++ b/Adapty.podspec
@@ -22,11 +22,15 @@ Adapty helps you track business metrics, and lets you run ad campaigns targeted 
   s.source           = { :git => 'https://github.com/adaptyteam/AdaptySDK-iOS.git', :tag => s.version.to_s }
 
   s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.14.4'
 
   s.swift_versions = ['5.0', '5.1']
   
   s.source_files = 'Adapty/Classes/**/*'
 
-  s.frameworks = 'Foundation', 'AdSupport', 'UIKit', 'StoreKit'
+  s.frameworks = 'Foundation', 'AdSupport', 'StoreKit'
+  s.ios.framework = 'UIKit'
+  s.osx.frameworks = 'AppKit'
+
   s.dependency "CryptoSwift"
 end

--- a/Adapty/Classes/Adapty.swift
+++ b/Adapty/Classes/Adapty.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import UIKit
 
 @objc public protocol AdaptyDelegate: class {
     
@@ -95,10 +94,12 @@ import UIKit
         }
         
         AppDelegateSwizzler.startSwizzlingIfPossible(self)
-        
+
+        #if os(iOS)
         NotificationCenter.default.addObserver(forName: UIApplication.didEnterBackgroundNotification, object: nil, queue: .main) { [weak self] (_) in
             self?.sessionsManager.trackLiveEventInBackground()
         }
+        #endif
     }
     
     private func performInitialRequests() {

--- a/Adapty/Classes/AppDelegateSwizzler.swift
+++ b/Adapty/Classes/AppDelegateSwizzler.swift
@@ -6,13 +6,12 @@
 //
 
 import Foundation
-import UIKit
 
 protocol AppDelegateSwizzlerDelegate: class {
     func didReceiveAPNSToken(_ deviceToken: Data)
 }
 
-private typealias RegisterForNotificationsClosureType = @convention(c) (AnyObject, Selector, UIApplication, Data) -> Void
+private typealias RegisterForNotificationsClosureType = @convention(c) (AnyObject, Selector, Application, Data) -> Void
 
 class AppDelegateSwizzler {
     
@@ -30,18 +29,18 @@ class AppDelegateSwizzler {
     }
     
     private init() {
-        if UIApplication.shared.isRegisteredForRemoteNotifications {
+        if Application.shared.isRegisteredForRemoteNotifications {
             DispatchQueue.main.async {
-                UIApplication.shared.registerForRemoteNotifications()
+                Application.shared.registerForRemoteNotifications()
             }
         }
         
         guard
-            let originalClass = object_getClass(UIApplication.shared.delegate),
+            let originalClass = object_getClass(Application.shared.delegate),
             let swizzledClass = object_getClass(self)
         else { return }
         
-        let originalSelector = #selector(UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:))
+        let originalSelector = #selector(ApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:))
         let swizzledSelector = #selector(swizzled_application(_:didRegisterForRemoteNotificationsWithDeviceToken:))
         
         swizzle(originalClass, swizzledClass, originalSelector, swizzledSelector)
@@ -64,9 +63,9 @@ class AppDelegateSwizzler {
         }
     }
     
-    @objc private func swizzled_application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+    @objc private func swizzled_application(_ application: Application, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         // call parent method
-        AppDelegateSwizzler.registerForNotificationsOriginalImp?(UIApplication.shared.delegate!, #selector(UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)), application, deviceToken)
+        AppDelegateSwizzler.registerForNotificationsOriginalImp?(Application.shared.delegate!, #selector(ApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)), application, deviceToken)
         
         // sync token to Adapty
         Self.shared.delegate?.didReceiveAPNSToken(deviceToken)

--- a/Adapty/Classes/Extensions.swift
+++ b/Adapty/Classes/Extensions.swift
@@ -18,6 +18,7 @@ extension Date {
     
 }
 
+#if os(iOS)
 extension UIDevice {
 
     static let modelName: String = {
@@ -96,6 +97,7 @@ extension UIDevice {
     }()
 
 }
+#endif
 
 extension Dictionary {
     

--- a/Adapty/Classes/IAPManager.swift
+++ b/Adapty/Classes/IAPManager.swift
@@ -82,7 +82,7 @@ class IAPManager: NSObject {
         
         getContainersAndSyncProducts()
         
-        NotificationCenter.default.addObserver(forName: UIApplication.willTerminateNotification, object: nil, queue: .main) { [weak self] (_) in
+        NotificationCenter.default.addObserver(forName: Application.willTerminateNotification, object: nil, queue: .main) { [weak self] (_) in
             self?.stopObserving()
         }
     }
@@ -364,7 +364,7 @@ extension IAPManager: SKPaymentTransactionObserver {
         
         let skProduct = self.skProduct(for: transaction)
         var discountPrice: NSDecimalNumber?
-        if #available(iOS 12.2, *) {
+        if #available(iOS 12.2, *, OSX 10.14.4, *) {
             discountPrice = skProduct?.discounts.filter({ $0.identifier == transaction.payment.paymentDiscount?.identifier }).first?.price
         }
         

--- a/Adapty/Classes/Platform.swift
+++ b/Adapty/Classes/Platform.swift
@@ -1,0 +1,18 @@
+//
+//  Platform.swift
+//  Adapty
+//
+//  Created by Dmitry Obukhov on 3/17/20.
+//
+
+#if os(iOS)
+import UIKit
+
+typealias Application = UIApplication
+typealias ApplicationDelegate = UIApplicationDelegate
+#elseif os(macOS)
+import AppKit
+
+typealias Application = NSApplication
+typealias ApplicationDelegate = NSApplicationDelegate
+#endif

--- a/Adapty/Classes/RequestManager.swift
+++ b/Adapty/Classes/RequestManager.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2019 Adapty. All rights reserved.
 //
 
-import UIKit
-
 enum HTTPMethod: String {
     case options = "OPTIONS"
     case get     = "GET"

--- a/Adapty/Classes/SessionsManager.swift
+++ b/Adapty/Classes/SessionsManager.swift
@@ -54,6 +54,7 @@ class SessionsManager {
                                   completion: completion)
     }
     
+    #if os(iOS)
     func trackLiveEventInBackground() {
         var eventBackgroundTaskID: UIBackgroundTaskIdentifier = .invalid
         eventBackgroundTaskID = UIApplication.shared.beginBackgroundTask (withName: "AdaptyTrackLiveBackgroundTask") {
@@ -72,5 +73,6 @@ class SessionsManager {
             }
         }
     }
+    #endif
     
 }

--- a/Adapty/Classes/UserProperties.swift
+++ b/Adapty/Classes/UserProperties.swift
@@ -43,7 +43,11 @@ class UserProperties {
     }
     
     static var device: String {
+        #if os(iOS)
         return UIDevice.modelName
+        #elseif os(macOS)
+        return "TODO: implement"
+        #endif
     }
     
     static var locale: String {
@@ -51,11 +55,19 @@ class UserProperties {
     }
     
     static var OS: String {
+        #if os(iOS)
         return "\(UIDevice.current.systemName) \(UIDevice.current.systemVersion)"
+        #elseif os(macOS)
+        return "TODO: implement"
+        #endif
     }
     
     static var platform: String {
+        #if os(iOS)
         return UIDevice.current.systemName
+        #elseif os(macOS)
+        return "TODO: implement"
+        #endif
     }
     
     static var timezone: String {
@@ -63,7 +75,11 @@ class UserProperties {
     }
     
     static var deviceIdentifier: String? {
+        #if os(iOS)
         return UIDevice.current.identifierForVendor?.uuidString
+        #elseif os(macOS)
+        return "TODO: implement"
+        #endif
     }
     
 }


### PR DESCRIPTION
Please note – this is not tested.

The macOS development target is set to 10.14.4 due to some of the latest `StoreKit` API, I believe it can be downgraded using availability conditions.

Have fun!