### PR TITLE
Update AppsFlyerFramework in Example to support Apple Silicon machines

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -6,7 +6,7 @@ target 'Adapty_Example' do
   pod 'Adapty', :path => '../'
   
   pod 'Adjust', '~> 4.29.6'
-  pod 'AppsFlyerFramework', '~> 6.0.5'
+  pod 'AppsFlyerFramework', '~> 6.6.0'
   pod 'Branch', '~> 0.33.1'
 
   target 'Adapty_Tests' do


### PR DESCRIPTION
The current version mentioned in the pods for AppsFlyerFramework does not have an arm64 binary. Updating it to the latest version contains the universal binary.