### PR TITLE
Update profile parameter builder

### DIFF
--- a/Adapty/Classes/Extensions.swift
+++ b/Adapty/Classes/Extensions.swift
@@ -16,6 +16,17 @@ extension Date {
         formatter.dateFormat = "YYYY-MM-dd"
         return formatter.string(from: self)
     }
+
+    init?(stringValue: String) {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "YYYY-MM-dd"
+
+        guard let date = formatter.date(from: stringValue) else {
+            return nil
+        }
+
+        self = date
+    }
     
     var iso8601Value: String {
         return DateFormatter.iso8601Formatter.string(from: self)

--- a/Adapty/Classes/ProfileParameterBuilder.swift
+++ b/Adapty/Classes/ProfileParameterBuilder.swift
@@ -16,96 +16,110 @@ import AppTrackingTransparency
     case other
 }
 
-public class ProfileParameterBuilder: NSObject {
-    
+public final class ProfileParameterBuilder: NSObject {
+
     private var params = Parameters()
 
-    @objc public func withEmail(_ email: String) -> Self {
-        params["email"] = email
-        return self
+    @objc public var email: String? {
+        get { params[String.ProfileKey.email] as? String }
+        set { params[String.ProfileKey.email] = newValue }
     }
-    
-    @objc public func withPhoneNumber(_ phoneNumber: String) -> Self {
-        params["phone_number"] = phoneNumber
-        return self
+
+    @objc public var phoneNumber: String? {
+        get { params[String.ProfileKey.phoneNumber] as? String }
+        set { params[String.ProfileKey.phoneNumber] = newValue }
     }
-    
-    @objc public func withFacebookUserId(_ facebookUserId: String) -> Self {
-        params["facebook_user_id"] = facebookUserId
-        return self
+
+    @objc public var facebookUserId: String? {
+        get { params[String.ProfileKey.facebookUserId] as? String }
+        set { params[String.ProfileKey.facebookUserId] = newValue }
     }
-    
-    @objc public func withFacebookAnonymousId(_ facebookAnonymousId: String) -> Self {
-        params["facebook_anonymous_id"] = facebookAnonymousId
-        return self
+
+    @objc public var facebookAnonymousId: String? {
+        get { params[String.ProfileKey.facebookAnonymousId] as? String }
+        set { params[String.ProfileKey.facebookAnonymousId] = newValue }
     }
-    
-    @objc public func withAmplitudeUserId(_ amplitudeUserId: String) -> Self {
-        params["amplitude_user_id"] = amplitudeUserId
-        return self
+
+    @objc public var amplitudeUserId: String? {
+        get { params[String.ProfileKey.amplitudeUserId] as? String }
+        set { params[String.ProfileKey.amplitudeUserId] = newValue }
     }
-    
-    @objc public func withAmplitudeDeviceId(_ amplitudeDeviceId: String) -> Self {
-        params["amplitude_device_id"] = amplitudeDeviceId
-        return self
+
+    @objc public var amplitudeDeviceId: String? {
+        get { params[String.ProfileKey.amplitudeDeviceId] as? String }
+        set { params[String.ProfileKey.amplitudeDeviceId] = newValue }
     }
-    
-    @objc public func withMixpanelUserId(_ mixpanelUserId: String) -> Self {
-        params["mixpanel_user_id"] = mixpanelUserId
-        return self
+
+    @objc public var mixpanelUserId: String? {
+        get { params[String.ProfileKey.mixpanelUserId] as? String }
+        set { params[String.ProfileKey.mixpanelUserId] = newValue }
     }
-    
-    @objc public func withAppmetricaProfileId(_ appmetricaProfileId: String) -> Self {
-        params["appmetrica_profile_id"] = appmetricaProfileId
-        return self
+
+    @objc public var appmetricaProfileId: String? {
+        get { params[String.ProfileKey.appmetricaProfileId] as? String }
+        set { params[String.ProfileKey.appmetricaProfileId] = newValue }
     }
-    
-    @objc public func withAppmetricaDeviceId(_ appmetricaDeviceId: String) -> Self {
-        params["appmetrica_device_id"] = appmetricaDeviceId
-        return self
+
+    @objc public var appmetricaDeviceId: String? {
+        get { params[String.ProfileKey.appmetricaDeviceId] as? String }
+        set { params[String.ProfileKey.appmetricaDeviceId] = newValue }
     }
-    
-    @objc public func withFirstName(_ firstName: String) -> Self {
-        params["first_name"] = firstName
-        return self
+
+    @objc public var firstName: String? {
+        get { params[String.ProfileKey.firstName] as? String }
+        set { params[String.ProfileKey.firstName] = newValue }
     }
-    
-    @objc public func withLastName(_ lastName: String) -> Self {
-        params["last_name"] = lastName
-        return self
+
+    @objc public var lastName: String? {
+        get { params[String.ProfileKey.lastName] as? String }
+        set { params[String.ProfileKey.lastName] = newValue }
     }
-    
-    @objc public func withGender(_ gender: Gender) -> Self {
-        switch gender {
-        case .female: params["gender"] = "f"
-        case .male: params["gender"] = "m"
-        case .other: params["gender"] = "o"
+
+    @objc public var gender: Gender? {
+        get {
+            params[String.ProfileKey.gender]
+                .flatMap { $0 as? String }
+                .flatMap { .init(stringValue: $0) }
         }
-        return self
+        set {
+            params[String.ProfileKey.gender] = newValue?.stringValue
+        }
     }
-    
-    @objc public func withBirthday(_ birthday: Date) -> Self {
-        params["birthday"] = birthday.stringValue
-        return self
+
+    @objc public var birthday: Date? {
+        get {
+            params[String.ProfileKey.birthday]
+                .flatMap { $0 as? String }
+                .flatMap { .init(stringValue: $0) }
+        }
+        set {
+            params[String.ProfileKey.birthday] = newValue?.stringValue
+        }
     }
-    
-    @objc public func withCustomAttributes(_ customAttributes: Parameters) -> Self {
-        params["custom_attributes"] = customAttributes.mapValues(makeJSONSerializable(_:))
-        return self
+
+    @objc public func setCustomAttributes(_ newValue: Parameters?) {
+        params[String.ProfileKey.customAttributes] = newValue?
+            .mapValues(makeJSONSerializable(_:))
     }
-    
+
     #if swift(>=5.3)
     @available(iOS 14, macOS 11.0, *)
-    @objc public func withAppTrackingTransparencyStatus(_ appTrackingTransparencyStatus: ATTrackingManager.AuthorizationStatus) -> Self {
-        params["att_status"] = appTrackingTransparencyStatus.rawValue
-        return self
+    @objc public var atTrackingAuthorizationStatus: ATTrackingManager.AuthorizationStatus? {
+        get {
+            params[String.ProfileKey.atTrackingAuthorizationStatus]
+                .flatMap { $0 as? UInt }
+                .flatMap { .init(rawValue: $0) }
+        }
+        set {
+            params[String.ProfileKey.atTrackingAuthorizationStatus] = newValue?.rawValue
+        }
     }
     #endif
-    
+
     func toDictionary() -> Parameters {
         return params
     }
-    
+
     private func makeJSONSerializable(_ param: Any) -> AnyObject {
         if let null = param as? NSNull {
             return null
@@ -137,7 +151,7 @@ public class ProfileParameterBuilder: NSObject {
         )
         return description
     }
-    
+
     private func coerceToString(key: Any) -> String {
         if let key = key as? String {
             return key
@@ -148,5 +162,145 @@ public class ProfileParameterBuilder: NSObject {
             )
             return description
         }
+    }
+}
+
+// MARK: - Deprecations
+
+extension ProfileParameterBuilder {
+    @available(*, deprecated, message: "use email instead.")
+    @objc public func withEmail(_ email: String) -> Self {
+        self.email = email
+        return self
+    }
+
+    @available(*, deprecated, message: "use phoneNumber instead.")
+    @objc public func withPhoneNumber(_ phoneNumber: String) -> Self {
+        self.phoneNumber = phoneNumber
+        return self
+    }
+
+    @available(*, deprecated, message: "use facebookUserId instead.")
+    @objc public func withFacebookUserId(_ facebookUserId: String) -> Self {
+        self.facebookUserId = facebookUserId
+        return self
+    }
+
+    @available(*, deprecated, message: "use facebookAnonymousId instead.")
+    @objc public func withFacebookAnonymousId(_ facebookAnonymousId: String) -> Self {
+        self.facebookAnonymousId = facebookAnonymousId
+        return self
+    }
+
+    @available(*, deprecated, message: "use amplitudeUserId instead.")
+    @objc public func withAmplitudeUserId(_ amplitudeUserId: String) -> Self {
+        self.amplitudeUserId = amplitudeUserId
+        return self
+    }
+
+    @available(*, deprecated, message: "use amplitudeDeviceId instead.")
+    @objc public func withAmplitudeDeviceId(_ amplitudeDeviceId: String) -> Self {
+        self.amplitudeDeviceId = amplitudeDeviceId
+        return self
+    }
+
+    @available(*, deprecated, message: "use mixpanelUserId instead.")
+    @objc public func withMixpanelUserId(_ mixpanelUserId: String) -> Self {
+        self.mixpanelUserId = mixpanelUserId
+        return self
+    }
+
+    @available(*, deprecated, message: "use appmetricaProfileId instead.")
+    @objc public func withAppmetricaProfileId(_ appmetricaProfileId: String) -> Self {
+        self.appmetricaProfileId = appmetricaProfileId
+        return self
+    }
+
+    @available(*, deprecated, message: "use appmetricaDeviceId instead.")
+    @objc public func withAppmetricaDeviceId(_ appmetricaDeviceId: String) -> Self {
+        self.appmetricaDeviceId = appmetricaDeviceId
+        return self
+    }
+
+    @available(*, deprecated, message: "use firstName instead.")
+    @objc public func withFirstName(_ firstName: String) -> Self {
+        self.firstName = firstName
+        return self
+    }
+
+    @available(*, deprecated, message: "use lastName instead.")
+    @objc public func withLastName(_ lastName: String) -> Self {
+        self.lastName = lastName
+        return self
+    }
+
+    @available(*, deprecated, message: "use gender instead.")
+    @objc public func withGender(_ gender: Gender) -> Self {
+        self.gender = gender
+        return self
+    }
+
+    @available(*, deprecated, message: "use birthday instead.")
+    @objc public func withBirthday(_ birthday: Date) -> Self {
+        self.birthday = birthday
+        return self
+    }
+
+    @available(*, deprecated, message: "use setCustomAttributes instead.")
+    @objc public func withCustomAttributes(_ customAttributes: Parameters) -> Self {
+        self.setCustomAttributes(customAttributes)
+        return self
+    }
+    
+    #if swift(>=5.3)
+    @available(iOS 14, macOS 11.0, *)
+    @available(*, deprecated, message: "use atTrackingAuthorizationStatus instead.")
+    @objc public func withAppTrackingTransparencyStatus(_ appTrackingTransparencyStatus: ATTrackingManager.AuthorizationStatus) -> Self {
+        self.atTrackingAuthorizationStatus = appTrackingTransparencyStatus
+        return self
+    }
+    #endif
+}
+
+private extension Gender {
+    var stringValue: String {
+        switch self {
+        case .female: return "f"
+        case .male: return "m"
+        case .other: return "o"
+        }
+    }
+
+    init?(stringValue: String) {
+        switch stringValue {
+        case "f":
+            self = .female
+        case "m":
+            self = .male
+        case "o":
+            self = .other
+        default:
+            return nil
+        }
+    }
+}
+
+private extension String {
+    enum ProfileKey {
+        static let email = "email"
+        static let phoneNumber = "phone_number"
+        static let facebookUserId = "facebook_user_id"
+        static let facebookAnonymousId = "facebook_anonymous_id"
+        static let amplitudeUserId = "amplitude_user_id"
+        static let amplitudeDeviceId = "amplitude_device_id"
+        static let mixpanelUserId = "mixpanel_user_id"
+        static let appmetricaProfileId = "appmetrica_profile_id"
+        static let appmetricaDeviceId = "appmetrica_device_id"
+        static let firstName = "first_name"
+        static let lastName = "last_name"
+        static let gender = "gender"
+        static let birthday = "birthday"
+        static let customAttributes = "customAttributes"
+        static let atTrackingAuthorizationStatus = "att_status"
     }
 }

--- a/Adapty/Classes/ProfileParameterBuilder.swift
+++ b/Adapty/Classes/ProfileParameterBuilder.swift
@@ -168,84 +168,98 @@ public final class ProfileParameterBuilder: NSObject {
 // MARK: - Deprecations
 
 extension ProfileParameterBuilder {
+    @discardableResult
     @available(*, deprecated, message: "use email instead.")
     @objc public func withEmail(_ email: String) -> Self {
         self.email = email
         return self
     }
 
+    @discardableResult
     @available(*, deprecated, message: "use phoneNumber instead.")
     @objc public func withPhoneNumber(_ phoneNumber: String) -> Self {
         self.phoneNumber = phoneNumber
         return self
     }
 
+    @discardableResult
     @available(*, deprecated, message: "use facebookUserId instead.")
     @objc public func withFacebookUserId(_ facebookUserId: String) -> Self {
         self.facebookUserId = facebookUserId
         return self
     }
 
+    @discardableResult
     @available(*, deprecated, message: "use facebookAnonymousId instead.")
     @objc public func withFacebookAnonymousId(_ facebookAnonymousId: String) -> Self {
         self.facebookAnonymousId = facebookAnonymousId
         return self
     }
 
+    @discardableResult
     @available(*, deprecated, message: "use amplitudeUserId instead.")
     @objc public func withAmplitudeUserId(_ amplitudeUserId: String) -> Self {
         self.amplitudeUserId = amplitudeUserId
         return self
     }
 
+    @discardableResult
     @available(*, deprecated, message: "use amplitudeDeviceId instead.")
     @objc public func withAmplitudeDeviceId(_ amplitudeDeviceId: String) -> Self {
         self.amplitudeDeviceId = amplitudeDeviceId
         return self
     }
 
+    @discardableResult
     @available(*, deprecated, message: "use mixpanelUserId instead.")
     @objc public func withMixpanelUserId(_ mixpanelUserId: String) -> Self {
         self.mixpanelUserId = mixpanelUserId
         return self
     }
 
+    @discardableResult
     @available(*, deprecated, message: "use appmetricaProfileId instead.")
     @objc public func withAppmetricaProfileId(_ appmetricaProfileId: String) -> Self {
         self.appmetricaProfileId = appmetricaProfileId
         return self
     }
 
+    @discardableResult
     @available(*, deprecated, message: "use appmetricaDeviceId instead.")
     @objc public func withAppmetricaDeviceId(_ appmetricaDeviceId: String) -> Self {
         self.appmetricaDeviceId = appmetricaDeviceId
         return self
     }
 
+    @discardableResult
     @available(*, deprecated, message: "use firstName instead.")
     @objc public func withFirstName(_ firstName: String) -> Self {
         self.firstName = firstName
         return self
     }
 
+    @discardableResult
     @available(*, deprecated, message: "use lastName instead.")
     @objc public func withLastName(_ lastName: String) -> Self {
         self.lastName = lastName
         return self
     }
 
+    @discardableResult
     @available(*, deprecated, message: "use gender instead.")
     @objc public func withGender(_ gender: Gender) -> Self {
         self.gender = gender
         return self
     }
 
+    @discardableResult
     @available(*, deprecated, message: "use birthday instead.")
     @objc public func withBirthday(_ birthday: Date) -> Self {
         self.birthday = birthday
         return self
     }
 
+    @discardableResult
     @available(*, deprecated, message: "use setCustomAttributes instead.")
     @objc public func withCustomAttributes(_ customAttributes: Parameters) -> Self {
         self.setCustomAttributes(customAttributes)
@@ -253,6 +267,7 @@ extension ProfileParameterBuilder {
     }
     
     #if swift(>=5.3)
+    @discardableResult
     @available(iOS 14, macOS 11.0, *)
     @available(*, deprecated, message: "use atTrackingAuthorizationStatus instead.")
     @objc public func withAppTrackingTransparencyStatus(_ appTrackingTransparencyStatus: ATTrackingManager.AuthorizationStatus) -> Self {


### PR DESCRIPTION
Current implementation is not convenient for setting properties, i.e.
- long signature
- not so "swifty" as it could be
- requires checks for optional values
- methods with*PropertyName* doesn't allow discard function result

e.g.

```swift
var builder = ProfileParameterBuilder()

let amplitude = Amplitude.instance()
builder = builder.withAmplitudeDeviceId(amplitude.deviceId)

if let userId = amplitude.userId {
  builder = builder.withAmplitudeUserId(userId)
}

if let fbProfile = Profile.current {
  builder = builder.withFacebookUserId(fbProfile.userID)
}
```

after merging PR it will be

```swift
let builder = ProfileParameterBuilder()
builder.amplitudeDeviceId = Amplitude.instance().deviceId
builder.amplitudeUserId = Amplitude.instance().userId
builder.facebookUserId = Profile.current.userId
```

Please check if it works for you, so I'll complete this PR then