### PR TITLE
Add macOS 10.15 condition, storefrontCountryCode

### DIFF
--- a/Adapty/Classes/IAPManager.swift
+++ b/Adapty/Classes/IAPManager.swift
@@ -65,7 +65,7 @@ class IAPManager: NSObject {
     }
 
     var storefrontCountryCode: String? {
-        if #available(iOS 13.0, *) {
+        if #available(iOS 13.0, macOS 10.15, *) {
             return SKPaymentQueue.default().storefront?.countryCode
         } else {
             return nil


### PR DESCRIPTION
Allows Adapty to compile as a package in hybrid iOS/macOS projects in the new Xcode 14.0