### PR TITLE
Compilation error fix

### DIFF
--- a/AdaptyUITesting/AdaptyUI+Testing.swift
+++ b/AdaptyUITesting/AdaptyUI+Testing.swift
@@ -149,7 +149,8 @@ public struct AdaptyUITestRendererView: View {
         let productsVM = AdaptyProductsViewModel(eventsHandler: eventsHandler,
                                                  paywallViewModel: paywallVM,
                                                  products: nil,
-                                                 introductoryOffersEligibilities: nil)
+                                                 introductoryOffersEligibilities: nil,
+                                                 observerModeResolver: nil)
         let tagResolverVM = AdaptyTagResolverViewModel(tagResolver: ["TEST_TAG": "Adapty"])
         let screensVM = AdaptyScreensViewModel(
             eventsHandler: eventsHandler,


### PR DESCRIPTION
Fixes #90

Initializer of `AdaptyProductsViewModel` now requires `observerModeResolver` parameter: https://github.com/adaptyteam/AdaptySDK-iOS/compare/3.0.0...3.0.1#diff-ec2557fc2fca143c1858d22d72abeb3ad8d85a7ab941dec7bacba55e94401817R71