### PR TITLE
Add AdaptyAttributionSource

### DIFF
--- a/Sources/Profile/Adapty+UpdateAttributionData.swift
+++ b/Sources/Profile/Adapty+UpdateAttributionData.swift
@@ -13,6 +13,19 @@ public extension Adapty {
     /// Read more on the [Adapty Documentation](https://docs.adapty.io/docs/attribution-integration)
     ///
     /// - Parameter attribution: a dictionary containing attribution (conversion) data.
+    /// - Parameter source: a source of attribution. The allowed values are: `.appsflyer`, `.adjust`, `.branch` or custom.
+    nonisolated static func updateAttribution(
+        _ attribution: [AnyHashable: Any],
+        source: AdaptyAttributionSource
+    ) async throws {
+        try await updateAttribution(attribution, source: source.rawValue)
+    }
+
+    /// To set attribution data for the profile, use this method.
+    ///
+    /// Read more on the [Adapty Documentation](https://docs.adapty.io/docs/attribution-integration)
+    ///
+    /// - Parameter attribution: a dictionary containing attribution (conversion) data.
     /// - Parameter source: a source of attribution. The allowed values are: `.appsflyer`, `.adjust`, `.branch`, `.custom`.
     nonisolated static func updateAttribution(
         _ attribution: [AnyHashable: Any],

--- a/Sources/Profile/AdaptyAttributionSource.swift
+++ b/Sources/Profile/AdaptyAttributionSource.swift
@@ -1,0 +1,36 @@
+//
+//  AdaptyAttributionSource.swift
+//  AdaptySDK
+//
+//  Created by Ilya Laryionau on 26.12.24.
+//
+
+public struct AdaptyAttributionSource: RawRepresentable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public static var adjust: Self { "adjust" }
+    public static var appsflyer: Self { "appsflyer" }
+    public static var branch: Self { "branch" }
+}
+
+extension AdaptyAttributionSource: CustomStringConvertible {
+    public var description: String {
+        return String(describing: self.rawValue)
+    }
+}
+
+extension AdaptyAttributionSource: Equatable {}
+
+extension AdaptyAttributionSource: ExpressibleByStringLiteral {
+    public init(stringLiteral: String) {
+        self.init(rawValue: stringLiteral)
+    }
+}
+
+extension AdaptyAttributionSource: Hashable {}
+
+extension AdaptyAttributionSource: Sendable {}


### PR DESCRIPTION
Add `AdaptyAttributionSource` to simplify the code and provide constants instead of strings, which are susceptible to typographical errors.