### PR TITLE
fix presenting AdaptUI from a modal view controller

### DIFF
--- a/AdaptyUI/Crossplatform/Plugin.swift
+++ b/AdaptyUI/Crossplatform/Plugin.swift
@@ -21,6 +21,18 @@ extension UIViewController {
     }
 }
 
+extension UIWindow {
+    fileprivate var topViewController: UIViewController? {
+        var topViewController = rootViewController
+    
+        while let presentedController = topViewController?.presentedViewController {
+            topViewController = presentedController
+        }
+        
+        return topViewController
+    }
+}
+
 #endif
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
@@ -87,7 +99,7 @@ package extension AdaptyUI {
                 throw AdaptyError(AdaptyUI.PluginError.viewNotFound(viewId))
             }
             
-            guard let rootVC = UIApplication.shared.windows.first?.rootViewController else {
+            guard let rootVC = UIApplication.shared.windows.first?.topViewController else {
                 throw AdaptyError(AdaptyUI.PluginError.viewPresentationError(viewId))
             }
             


### PR DESCRIPTION
When adapty UI is presented from a view controller which is presented modally, we got this error

```
Attempt to present <AdaptyUI.AdaptyPaywallController: 0x152e89e00> on <UIViewController: 0x102b00400> (from <UIViewController: 0x102b00400>) which is already presenting
```

It happens on a react native app, but I think that it will happen on a 100% native app.

This MR fixes the issue, using the current top controller of the app to present it. 