### PR TITLE
added unsafe for ios 26 SK2Purchaser.swift

### DIFF
--- a/Sources/StoreKit/SK2Purchaser.swift
+++ b/Sources/StoreKit/SK2Purchaser.swift
@@ -18,7 +18,7 @@ actor SK2Purchaser {
         self.storage = storage
     }
 
-    private static var isObservingStarted = false
+    nonisolated(unsafe) private static var isObservingStarted = false
 
     static func startObserving(
         purchaseValidator: PurchaseValidator,


### PR DESCRIPTION
This is a temporary fix in place for those who are internally testing the adapty sdk while the team are working on a proper implementation