### PR TITLE
fix: overlay and content swapped on container elements

### DIFF
--- a/Sources.UIBuilder/UISchema/Elements/Schema.Element.Properties.swift
+++ b/Sources.UIBuilder/UISchema/Elements/Schema.Element.Properties.swift
@@ -143,7 +143,7 @@ extension Schema.Element.Properties: DecodableWithConfiguration {
         )
 
         let overlay = try container.decodeIfPresent([Schema.Element.Overlay].self, forKey: .overlay, configuration: configuration)
-        let background = try container.decodeIfPresent([Schema.Element.Overlay].self, forKey: .overlay, configuration: configuration)
+        let background = try container.decodeIfPresent([Schema.Element.Overlay].self, forKey: .background, configuration: configuration)
 
         try self.init(
             legacyElementId: container.decodeIfPresent(String.self, forKey: .legacyElementId),

--- a/Sources.UIBuilder/UISchema/Elements/Schema.Element.swift
+++ b/Sources.UIBuilder/UISchema/Elements/Schema.Element.swift
@@ -60,32 +60,32 @@ extension Schema.ConfigurationBuilder {
             planElementProperties(properties, in: &taskStack)
         case let .stack(value, properties):
             taskStack.append(.buildElement(from))
-            planStack(value, in: &taskStack)
             planElementProperties(properties, in: &taskStack)
+            planStack(value, in: &taskStack)
         case let .button(value, properties):
             taskStack.append(.buildElement(from))
-            planButton(value, in: &taskStack)
             planElementProperties(properties, in: &taskStack)
+            planButton(value, in: &taskStack)
         case let .box(value, properties):
             taskStack.append(.buildElement(from))
-            planBox(value, in: &taskStack)
             planElementProperties(properties, in: &taskStack)
+            planBox(value, in: &taskStack)
         case let .row(value, properties):
             taskStack.append(.buildElement(from))
-            planRow(value, in: &taskStack)
             planElementProperties(properties, in: &taskStack)
+            planRow(value, in: &taskStack)
         case let .column(value, properties):
             taskStack.append(.buildElement(from))
-            planColumn(value, in: &taskStack)
             planElementProperties(properties, in: &taskStack)
+            planColumn(value, in: &taskStack)
         case let .section(value, properties):
             taskStack.append(.buildElement(from))
-            planSection(value, in: &taskStack)
             planElementProperties(properties, in: &taskStack)
+            planSection(value, in: &taskStack)
         case let .pager(value, properties):
             taskStack.append(.buildElement(from))
-            planPager(value, in: &taskStack)
             planElementProperties(properties, in: &taskStack)
+            planPager(value, in: &taskStack)
         case .screenHolder:
             taskStack.append(.buildElement(from))
         }


### PR DESCRIPTION
## Summary

- **`background` decoded from wrong key**: `Schema.Element.Properties` decoded `background` overlays from `.overlay` key instead of `.background`, making the `background` property completely non-functional
- **Overlay/content swap on containers**: For all container elements (stack, button, box, row, column, section, pager), the LIFO task stack planning order caused overlay and content results to be swapped during build — overlay got the content, and content got the overlay

## Root cause

In `planElement`, content was planned before `planElementProperties` (overlay/background). Since tasks are processed LIFO, overlay was built first (result at bottom of result stack), then content (result on top). During `buildElement`, `buildElementProperties` popped from the top — getting content instead of overlay — and `buildBox`/etc. popped next — getting overlay instead of content.

## Fix

1. `Schema.Element.Properties.swift:146` — changed `.overlay` → `.background` for the `background` decoding key
2. `Schema.Element.swift:61-88` — swapped planning order: `planElementProperties` now comes before `planBox`/`planStack`/etc. for all 7 container element types

## Test plan

- [ ] Verify overlay badges render correctly on leaf elements (image, text) — should be unchanged
- [ ] Verify overlay badges render correctly on container elements (box with content + overlay)
- [ ] Verify `background` property works (renders behind the element)
- [ ] Test with `library/elements/overlay_badges.bundle` in the Gallery app

🤖 Generated with [Claude Code](https://claude.com/claude-code)