### PR TITLE
fix: text fields with nested variable paths share the same value

### DIFF
--- a/Sources.UIBuilder/UIState/JS/VS.JSState.swift
+++ b/Sources.UIBuilder/UIState/JS/VS.JSState.swift
@@ -89,7 +89,7 @@ extension VS.JSState {
             index += 1
         }
 
-        guard index < path.count - 1 else { return current }
+        guard index < path.count else { return current }
         guard createIfNeeded else {
             throw .jsObjectNotFound(path.joined(separator: "."))
         }
@@ -267,9 +267,14 @@ extension VS.JSState {
             objectWillChange.send()
             return
         } catch {
-            guard case .jsMethodNotFound = error else { throw error }
-            if variable.setter != nil {
-                log.warn("not found setter \(setter.joined(separator: "."))")
+            if case .jsMethodNotFound = error {
+                if variable.setter != nil {
+                    log.warn("not found setter \(setter.joined(separator: "."))")
+                }
+            } else if case .jsObjectNotFound = error {
+                // parent object doesn't exist yet — fall through to createIfNeeded
+            } else {
+                throw error
             }
         }
 


### PR DESCRIPTION
## Summary

- **All `text_field` elements with dot-separated variable paths** (e.g. `inp_e5.value`, `inp_e11.value`) were reading and writing the same `globalObject.value` instead of their own namespaced properties
- Typing in one field caused all other fields to display the same text
- Fields with flat variable names (e.g. `fullName`, `email`) were unaffected

## Root cause

Two bugs in `VS.JSState.findObject`:

### 1. Off-by-one in the traversal guard (line 92)

```swift
// Before:
guard index < path.count - 1 else { return current }
// After:
guard index < path.count else { return current }
```

When `findObject` is called with path `["inp_e5"]` and `inp_e5` doesn't exist in JSContext:
- `index = 0` (broke out of the while loop)
- `path.count - 1 = 0`
- `0 < 0` → false → **returns `globalObject`** instead of throwing/creating

Since `findObject` is always called with `path.dropLast()`, the `-1` tolerance is wrong — it makes the function silently return `globalObject` when the parent object is missing.

### 2. `setValueWithoutConverter` catch clause too restrictive (line 270)

The setter lookup (`invokeMethod`) calls `findObject`, which now correctly throws `.jsObjectNotFound`. But the catch clause only handled `.jsMethodNotFound`:

```swift
// Before:
guard case .jsMethodNotFound = error else { throw error }
```

This rethrew `.jsObjectNotFound`, so the code never reached the `findObject(createIfNeeded: true)` path that would auto-create the parent object. Fix: also allow `.jsObjectNotFound` to fall through.

## How to reproduce

Open the `input.bundle` example from UIBuilder-Gallery — all text fields share the same typed value.

## Test plan

- [ ] Open `input.bundle` — each text field stores its own value independently
- [ ] Open `text_field_form.bundle` — no regression (uses flat variable names)
- [ ] Date/time picker fields in `input.bundle` still work (they use script-initialized objects)