### PR TITLE
fix: completion-handler parity for AdaptyUI.getFlowConfiguration + narrow JSON-string attribution API to package

### DIFF
--- a/Sources.AdaptyUI/AdaptyUI+Callbacks.swift
+++ b/Sources.AdaptyUI/AdaptyUI+Callbacks.swift
@@ -30,26 +30,35 @@ public extension AdaptyUI {
     ///
     /// - Parameters:
     ///   - forFlow: the ``AdaptyFlow`` for which you want to get a configuration.
+    ///   - locale: the locale to use when resolving the flow's localized content. Pass `nil` to use the default locale.
+    ///   - customLayoutId: the identifier of a custom layout to use instead of the one resolved automatically for the current device.
     ///   - loadTimeout: the `TimeInterval` value which limits the request time. Cached or Fallback result will be returned in case of timeout exceeds.
+    ///   - assetsResolver: if you are going to use custom assets functionality, pass the resolver function here.
     ///   - completion: A result containing the ``AdaptyUI.FlowConfiguration`` object. Use it with [AdaptyUI](https://github.com/adaptyteam/AdaptySDK-iOS-VisualPaywalls.git) library.
     static func getFlowConfiguration(
         forFlow flow: AdaptyFlow,
-        loadTimeout: TimeInterval = 5.0,
+        locale: String? = nil,
+        customLayoutId: String? = nil,
+        loadTimeout: TimeInterval? = nil,
         products: [AdaptyPaywallProduct]? = nil,
         observerModeResolver: AdaptyObserverModeResolver? = nil,
         tagResolver: AdaptyUITagResolver? = nil,
         timerResolver: AdaptyTimerResolver? = nil,
+        assetsResolver: AdaptyUIAssetsResolver? = nil,
         systemRequestsHandler: AdaptyUISystemRequestsHandler? = nil,
         _ completion: @escaping AdaptyResultCompletion<FlowConfiguration>
     ) {
         withCompletion(completion) {
             try await AdaptyUI.getFlowConfiguration(
                 forFlow: flow,
+                locale: locale,
+                customLayoutId: customLayoutId,
                 loadTimeout: loadTimeout,
                 products: products,
                 observerModeResolver: observerModeResolver,
                 tagResolver: tagResolver,
                 timerResolver: timerResolver,
+                assetsResolver: assetsResolver,
                 systemRequestsHandler: systemRequestsHandler
             )
         }

--- a/Sources/Profile/Adapty+UpdateExternalAttributionData.swift
+++ b/Sources/Profile/Adapty+UpdateExternalAttributionData.swift
@@ -42,9 +42,13 @@ public extension Adapty {
     /// processing. A successful return does not mean that the data has already
     /// been processed or that the profile has already been updated.
     ///
+    /// Intended for the cross-platform bridge, which already holds the
+    /// attribution as a JSON string. Application code should use the
+    /// `[AnyHashable: Any]` overload instead.
+    ///
     /// - Parameter attributionJson: Attribution data supplied by the provider as a JSON string.
     /// - Parameter provider: The external attribution provider.
-    nonisolated static func updateExternalAttribution(
+    package nonisolated static func updateExternalAttribution(
         _ attributionJson: String,
         provider: AdaptyExternalAttributionProvider
     ) async throws(AdaptyError) {


### PR DESCRIPTION
## Summary

Rebased onto `release/4.1.0` and retargeted there, so these land in 4.1.0 rather than 4.2.0.

- **`AdaptyUI.getFlowConfiguration(forFlow:...)`** — the completion overload was missing the `locale`, `customLayoutId`, and `assetsResolver` parameters present in the async version, and hardcoded `loadTimeout` to `5.0` instead of deferring to the shared default (`nil` → `.defaultLoadPlacementTimeout`). Additive and source-compatible: new parameters have defaults, existing call sites are unaffected.
- **`updateExternalAttribution(_ attributionJson: String, provider:)` is now `package`** instead of `public`, per review. It exists for `AdaptyPlugin`, which already holds the attribution as a JSON string; every attribution provider we support hands back a dictionary, so application code should go through the `[AnyHashable: Any]` overload. Keeping the JSON-string form out of the public API also avoids blessing it as the shape for token-based providers like `google_odm_token`, which needs its own API design. Follows the existing `setIntegrationIdentifier` / `setIntegrationIdentifiers` pattern.

`nonisolated` on `getUnfinishedTransactions(_:)` — the third item from the original PR — is already on `release/4.1.0` via c810215, so it dropped out of this diff during the rebase.

## Test plan

- [x] `swift build` — succeeds
- [x] `swift test` — 280 tests in 22 suites pass
- [x] `xcodebuild -scheme AdaptyUI -destination 'generic/platform=iOS'` — succeeds. Needed because `AdaptyUI+Callbacks.swift` sits entirely under `#if canImport(UIKit) && ...`, so a macOS `swift build` never compiles the AdaptyUI change at all.
- [x] `xcodebuild -scheme AdaptyPlugin -destination 'generic/platform=iOS'` — succeeds, confirming the `package` method is still reachable from the plugin target.
- [ ] CI

> Note: targeting `release/4.1.0` means `dev` gets these only via the usual back-merge of the release branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
