### PR TITLE
fix(ui): honor includeBackground for non-animated decorator backgrounds

### DIFF
--- a/Sources.UIBuilder/UIBuilder/Rendering/Modifiers/Animations/AdaptyUIAnimatableDecoratorModifier.swift
+++ b/Sources.UIBuilder/UIBuilder/Rendering/Modifiers/Animations/AdaptyUIAnimatableDecoratorModifier.swift
@@ -349,6 +349,7 @@ struct AdaptyUIAnimatableDecoratorModifier: ViewModifier {
             content
                 .background {
                     self.backgroundFill(for: background)
+                        .opacity(includeBackground ? 1.0 : 0.0)
                 }
         } else {
             content


### PR DESCRIPTION
## Regression

Since 4.0.0, `AdaptyUIAnimatableDecoratorModifier.bodyWithBackground` applies the `includeBackground` opacity gate only in the animated-background branch; the static branch paints the decorator background unconditionally:

```swift
if let animatedBackgroundFilling {
    content.background {
        self.backgroundFill(for: animatedBackgroundFilling)
            .opacity(includeBackground ? 1.0 : 0.0)   // gated
    }
} else if let background = self.decorator.background {
    content.background {
        self.backgroundFill(for: background)          // NOT gated
    }
}
```

In 3.17.x every branch was gated (`AdaptyUIDecoratorModifier`, all three branches applied `.opacity(includeBackground ? 1.0 : 0.0)`).

## Visible effect

The footer is the only element rendered with `includeBackground == false` (`drawDecoratorBackground` in `AdaptyUIHeroContainerView` / `AdaptyUIFlatContainerView`): its background is meant to appear only once scrollable content extends beneath the footer. With the gate lost, a translucent footer background (e.g. `#000000BF` in dark mode) is composited over the screen content unconditionally, visibly darkening the footer band on any paywall using one.

Measured on a production paywall (legacy Paywall Builder template `basic`, dark mode): footer band `rgb(57,57,57)` under 3.17.2 vs `rgb(14,14,14)` under 4.0.2 — exactly one extra application of the `#000000BF` scrim over the same backdrop.

## Fix

Restore the gate on the static branch, matching the animated branch and the 3.x behavior. One line.