### PR TITLE
fix(UIBuilder): flat and hero layouts reserve the footer height twice for screen-relative content

### DIFF
--- a/Sources.UIBuilder/UIBuilder/Rendering/Environment/AdaptyUIScreenSizeEnvironment.swift
+++ b/Sources.UIBuilder/UIBuilder/Rendering/Environment/AdaptyUIScreenSizeEnvironment.swift
@@ -64,9 +64,31 @@ extension EnvironmentValues {
     }
 }
 
+/// Narrows `adaptyScreenSize` to the area above an overlaid footer, height only.
+///
+/// Flat and hero append a footer-height filler below their scrolling content, so a
+/// `.screen` height inside it has to resolve against the screen less the footer or
+/// the footer is reserved twice.
+struct AdaptyUIScreenSizeAboveFooterModifier: ViewModifier {
+    @Environment(\.adaptyScreenSize)
+    private var screenSize: CGSize
+
+    let footerHeight: CGFloat
+
+    func body(content: Content) -> some View {
+        content.withScreenSize(
+            CGSize(width: screenSize.width, height: max(0, screenSize.height - footerHeight))
+        )
+    }
+}
+
 extension View {
     package func withScreenSize(_ value: CGSize) -> some View {
         environment(\.adaptyScreenSize, value)
+    }
+
+    func withScreenSizeAboveFooter(_ footerHeight: CGFloat) -> some View {
+        modifier(AdaptyUIScreenSizeAboveFooterModifier(footerHeight: footerHeight))
     }
 
     func withScreenInstance(_ value: VS.ScreenInstance) -> some View {

--- a/Sources.UIBuilder/UIBuilder/Rendering/Layouts/AdaptyUIFlatContainerView.swift
+++ b/Sources.UIBuilder/UIBuilder/Rendering/Layouts/AdaptyUIFlatContainerView.swift
@@ -80,6 +80,7 @@ struct AdaptyUIFlatContainerView: View {
                                 screen.content,
                                 screenHolderBuilder: { EmptyView() }
                             )
+                            .withScreenSizeAboveFooter(footerSize.height)
                             .id(ScrollAnchor.contentTop)
                             .frame(maxWidth: .infinity)
 

--- a/Sources.UIBuilder/UIBuilder/Rendering/Layouts/AdaptyUIHeroContainerView.swift
+++ b/Sources.UIBuilder/UIBuilder/Rendering/Layouts/AdaptyUIHeroContainerView.swift
@@ -207,6 +207,7 @@ struct AdaptyUIHeroContainerView: View {
                     playAnimations: $playOnAppearAnimations,
                     screenHolderBuilder: { EmptyView() }
                 )
+                .withScreenSizeAboveFooter(footerSize.height)
 
                 FooterVerticalFillerView(height: footerSize.height) { frame in
                     withAnimation {


### PR DESCRIPTION
## What happens

In a flat layout with a footer, a content box whose height is expressed in screen units comes out one footer-height too tall, with the surplus above its children. The paywall gains scroll it should not have and the last element sits under the footer at rest.

Measured frame by frame on a 430 × 932 pt device (recording 1290 × 2796 px), AdaptySDK-iOS 4.1.2, flat layout with a footer and a content box with a vertical alignment:

```
AdaptyUI container          y  59.0 → 932.0      viewport height   873.0
Footer                      y 765.7 → 932.0      footer height     166.3
Content (first to last px)                       content height    608.7

blank space ABOVE the content, at rest           205.3
blank space BELOW the content, scrolled down     207.0
scroll travel                                    148.0
total scroll content height                     1021.0
```

The space above and below are equal; only the bottom should reserve the footer. Subtracting the box's own padding — 207.0 − 166.3 = 40.7 — leaves 205.3 − 40.7 = 164.6 pt above the content: the footer's height. The layout is `[footer] + [content] + [footer]`. Correctly laid out this content is 854.7 pt in an 873.0 pt viewport and would not scroll at all. The web editor renders the same paywall without the top gap; the Adapty app's flow preview reproduces it.

## Why

`AdaptyUIPaywallView_Internal` sets `adaptyScreenSize` to the whole screen, safe areas included, and `AdaptyUIRangedFrameModifier` resolves a box's `.screen(x)` height through `Length.points` as `x × screenSize.height`. `AdaptyUIFlatContainerView` renders its content with that environment untouched and then appends `FooterVerticalFillerView(height: footerSize.height)` beneath it — so a content box that fills the screen is the whole screen tall, footer area included, and the filler adds the footer again. `AdaptyUIHeroContainerView` builds its content the same way, content then filler, and has the same double count for a screen-relative height inside its content.

## Fix

One principle, stated once: **in a layout that overlays a footer on scrolling content, the content's screen units resolve against the screen less the footer — the area the editor draws it in.**

`withScreenSizeAboveFooter(_:)` in `AdaptyUIScreenSizeEnvironment.swift` narrows the screen size a content element sees to `screen − footerHeight`, height only, and the two containers that overlay a footer on scrolling content apply it to their content element:

```swift
// AdaptyUIFlatContainerView, AdaptyUIHeroContainerView
.withScreenSizeAboveFooter(footerSize.height)
```

`footerSize` is the same measured value the filler is given, so the box and the filler cannot disagree. Nothing else reads a different number: the cover in the hero layout is sized at the container level, outside the narrowed subtree, and keeps the whole screen.

`AdaptyUITransparentContainerView` is deliberately untouched. Its content is a static full-screen layer that the footer scrolls over, with no filler, so the whole screen is the correct basis there — the subtraction it already does at line 33 is the footer's initial scroll offset, not content sizing.

## Scope and a question for the maintainers

The modifier narrows every screen-relative height inside the content, not only the root box, on the reading that the editor's content area is what all of them are measured against. If the editor resolves nested elements against the whole screen instead, the same modifier applied to the root box's frame alone would be the shape — but that would leave the environment stating a size the content cannot use, which is how this bug was made.

## Repro

Flat layout + footer + a content box with a vertical alignment and a screen-relative height, on a device tall enough that the content fits above the footer.